### PR TITLE
Fix typo in attribution on "All shapes" page

### DIFF
--- a/src/squanmate/pages/all_possible_shapes.cljs
+++ b/src/squanmate/pages/all_possible_shapes.cljs
@@ -63,7 +63,7 @@
    [:a {:href "http://www.cubezone.be/square1step1.html"
         :target "_blank"}
     "Lars Vandenbergh's CubeZone"]
-   ". It is genious, and should be attributed to him."])
+   ". It is genius, and should be attributed to him."])
 
 (defn content []
   [:div.row.col-xs-12


### PR DESCRIPTION
This is a tiny PR to fix a typo on the "All shapes" page, where "genius" was misspelled as "genious".